### PR TITLE
Fix  non-zero exit status from zypper ps

### DIFF
--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -73,12 +73,14 @@ def patch(stdout=None):
             break
         elif rc == 102:
             # patch requires reboot.
-            # should normally not happen, as we skipped interactive patches.
             break
         elif rc == 103:
             # restart of package manager needed.
             continue
-    Zypper.ps(stdout=stdout)
+    rc = Zypper.ps(stdout=stdout)
+    if rc == 102:
+        # zypper ps reports that reboot is required.
+        print("\nreboot is required", file=stdout)
     return True
 
 if __name__ == "__main__":

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -56,8 +56,11 @@ class Zypper:
 
     @classmethod
     def ps(cls, stdout=None):
+        # ps: list processes using deleted files
+        # 0: ok
+        # 102: reboot required
         args = ["--quiet", "ps"]
-        return cls.call(args, stdout=stdout)
+        return cls.call(args, stdout=stdout, retcodes={102})
 
 
 def patch(stdout=None):


### PR DESCRIPTION
The `auto-patch` script may fail with the following error message:
```
$ auto-patch
Traceback (most recent call last):
  File "/usr/sbin/auto-patch", line 83, in <module>
    if patch(stdout=tmpf):
  File "/usr/sbin/auto-patch", line 78, in patch
    Zypper.ps(stdout=stdout)
  File "/usr/sbin/auto-patch", line 60, in ps
    return cls.call(args, stdout=stdout)
  File "/usr/sbin/auto-patch", line 31, in call
    proc.check_returncode()
  File "/usr/lib64/python3.6/subprocess.py", line 389, in check_returncode
    self.stderr)
subprocess.CalledProcessError: Command '['/usr/bin/zypper', '--quiet', 'ps']' returned non-zero exit status 102.
```

The cause is that `zypper ps` may return a 102 exit status if core libraries have been updated so that a reboot is needed.  This PR takes this condition into account.