### PR TITLE
Retry if the ZYPP library is locked

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+
+1.0.2 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Bug fixes and minor changes
+---------------------------
+
++ `#2`_, `#4`_: retry if the ZYPP library is locked.
+
+.. _#2: https://github.com/RKrahl/auto-patch/issues/2
+.. _#4: https://github.com/RKrahl/auto-patch/pull/4
+
+
 1.0.1 (2020-08-19)
 ~~~~~~~~~~~~~~~~~~
 
@@ -14,6 +27,7 @@ Bug fixes and minor changes
 + Add Changelog.
 
 .. _#1: https://github.com/RKrahl/auto-patch/pull/1
+
 
 1.0 (2020-07-26)
 ~~~~~~~~~~~~~~~~

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -74,13 +74,15 @@ class Zypper:
 
 
 def patch(stdout=None):
+    have_patches = False
     try_count = 0
     while True:
         try_count += 1
         try:
-            if Zypper.patch_check(stdout=stdout) == 0:
-                return False
             while True:
+                if Zypper.patch_check(stdout=stdout) == 0:
+                    return break
+                have_patches = True
                 Zypper.list_patches(stdout=stdout)
                 rc = Zypper.patch(stdout=stdout)
                 if rc == 0:
@@ -91,6 +93,8 @@ def patch(stdout=None):
                 elif rc == 103:
                     # restart of package manager needed.
                     continue
+            if not have_patches:
+                return False
             rc = Zypper.ps(stdout=stdout)
             if rc == 102:
                 # zypper ps reports that reboot is required.
@@ -105,7 +109,7 @@ def patch(stdout=None):
             else:
                 print("\nZYPP library is locked.  "
                       "Giving up after %d tries." % try_count, file=stdout)
-                return True
+                return have_patches
 
 if __name__ == "__main__":
     with tempfile.TemporaryFile(mode='w+t') as tmpf:

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -102,8 +102,6 @@ def patch(stdout=None):
             return True
         except ZypperLockedError:
             if try_count < lock_max_tries:
-                print("\nZYPP library is locked.  Will try again ...",
-                      file=stdout)
                 sleep(lock_wait)
                 continue
             else:

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -17,6 +17,11 @@ mailto = os.environ.get('MAILTO', None) or ("root@%s" % host)
 mailsubject = "auto-patch %s" % host
 
 
+class ZypperLockedError(Exception):
+    def __init__(self):
+        super().__init__("ZYPP library is locked")
+
+
 class Zypper:
 
     _zypper = "/usr/bin/zypper"
@@ -26,7 +31,9 @@ class Zypper:
         cmd = [cls._zypper] + args
         proc = subprocess.run(cmd, stdout=stdout, stderr=subprocess.PIPE,
                               universal_newlines=True)
-        if (proc.returncode != 0 and
+        if proc.returncode == 7:
+            raise ZypperLockedError()
+        elif (proc.returncode != 0 and
             not (retcodes and proc.returncode in retcodes)):
             proc.check_returncode()
         return proc.returncode


### PR DESCRIPTION
Properly handle the error from `zypper` if the `ZYPP` library is locked by another process.  Retry for half an hour before giving up.

This fixes #2.

Note that this is controlled by two variables `lock_max_tries` and `lock_wait` that are hard coded for the moment.  These options should rather be made configurable.

Furthermore there are more error conditions from `zypper` that should also be properly handled, such as code 106 that will be returned on network failure. In most of these cases the proper reaction will probably be just throwing an error, which is what also happens now, albeit with an incomprehensible error message.  Thus, I'll leave them open for the moment.