### PR TITLE
Add logging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@ Changelog
 =========
 
 
+1.1.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
++ `#3`_, `#5`_: add logging.
+
+.. _#3: https://github.com/RKrahl/auto-patch/issues/3
+.. _#5: https://github.com/RKrahl/auto-patch/pull/5
+
+
 1.0.3 (2020-10-24)
 ~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ External programs:
 
 Required library packages:
 
-+ None
++ `python-systemd`_
 
 Optional library packages:
 
@@ -51,5 +51,6 @@ permissions and limitations under the License.
 
 
 .. _zypper: https://github.com/openSUSE/zypper
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm/
+.. _python-systemd: https://github.com/systemd/python-systemd
+.. _setuptools_scm: https://github.com/pypa/setuptools_scm
 .. _Apache License: https://www.apache.org/licenses/LICENSE-2.0

--- a/auto-patch.spec
+++ b/auto-patch.spec
@@ -9,6 +9,7 @@ Source:		%{name}-%{version}.tar.gz
 BuildRequires:	python3-base >= 3.5
 BuildRequires:	systemd-rpm-macros
 Requires:	lsof
+Requires:	python3-systemd
 Requires:	systemd
 Requires:	zypper
 %systemd_requires

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -100,21 +100,16 @@ def patch(stdout=None):
         have_patches = True
         Zypper.list_patches(stdout=stdout)
         rc = Zypper.patch(stdout=stdout)
-        if rc == 0:
-            log.debug("patches successfully installed")
-            break
-        elif rc == 102:
-            log.debug("patches successfully installed, patch requires reboot")
+        log.info("patches successfully installed")
+        if rc == 0 or rc == 102:
             break
         elif rc == 103:
-            log.debug("patches successfully installed, "
-                      "need to check again for more patches")
+            log.info("patch requires restart to check again for more patches")
             continue
     if not have_patches:
         return False
     rc = Zypper.ps(stdout=stdout)
     if rc == 102:
-        # zypper ps reports that reboot is required.
         print("\nreboot is required", file=stdout)
         log.warning("reboot is required after installing patches")
     return True

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -18,13 +18,14 @@ import systemd.journal
 os.environ['LANG'] = "POSIX"
 os.environ['LC_CTYPE'] = "en_US.UTF-8"
 
-journal = systemd.journal.JournalHandler(level=logging.INFO)
-logging.getLogger().addHandler(journal)
+journal_hdlr = systemd.journal.JournalHandler(level=logging.INFO)
+logging.getLogger().addHandler(journal_hdlr)
 if os.isatty(sys.stderr.fileno()):
-    stderr = logging.StreamHandler()
-    stderr.setLevel(logging.DEBUG)
-    stderr.setFormatter(logging.Formatter(fmt="%(levelname)s: %(message)s"))
-    logging.getLogger().addHandler(stderr)
+    stderr_hdlr = logging.StreamHandler()
+    stderr_hdlr.setLevel(logging.DEBUG)
+    fmt = "%(levelname)s: %(message)s"
+    stderr_hdlr.setFormatter(logging.Formatter(fmt=fmt))
+    logging.getLogger().addHandler(stderr_hdlr)
 logging.getLogger().setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -74,11 +74,13 @@ class Zypper:
 
 
 def patch(stdout=None):
-    if Zypper.patch_check(stdout=stdout) == 0:
-        log.debug("no patches needed")
-        return False
-    log.info("installing patches ...")
+    have_patches = False
     while True:
+        if Zypper.patch_check(stdout=stdout) == 0:
+            log.debug("no patches needed")
+            break
+        have_patches = True
+        log.info("installing patches ...")
         Zypper.list_patches(stdout=stdout)
         rc = Zypper.patch(stdout=stdout)
         if rc == 0:
@@ -91,6 +93,8 @@ def patch(stdout=None):
             log.debug("patches successfully installed, "
                       "need to check again for more patches")
             continue
+    if not have_patches:
+        return False
     rc = Zypper.ps(stdout=stdout)
     if rc == 102:
         # zypper ps reports that reboot is required.

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -13,14 +13,19 @@ import subprocess
 import sys
 import tempfile
 
+import systemd.journal
+
 os.environ['LANG'] = "POSIX"
 os.environ['LC_CTYPE'] = "en_US.UTF-8"
 
-log_level = logging.INFO
+journal = systemd.journal.JournalHandler(level=logging.INFO)
+logging.getLogger().addHandler(journal)
 if os.isatty(sys.stderr.fileno()):
-    log_level = logging.DEBUG
-
-logging.basicConfig(level=log_level, format="%(levelname)s: %(message)s")
+    stderr = logging.StreamHandler()
+    stderr.setLevel(logging.DEBUG)
+    stderr.setFormatter(logging.Formatter(fmt="%(levelname)s: %(message)s"))
+    logging.getLogger().addHandler(stderr)
+logging.getLogger().setLevel(logging.DEBUG)
 log = logging.getLogger(__name__)
 
 host = socket.getfqdn()

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -114,7 +114,12 @@ def patch(stdout=None):
         log.warning("reboot is required after installing patches")
     return True
 
+def exchandler(type, value, traceback):
+    log.critical("%s: %s", type.__name__, value,
+                 exc_info=(type, value, traceback))
+
 if __name__ == "__main__":
+    sys.excepthook = exchandler
     with tempfile.TemporaryFile(mode='w+t') as tmpf:
         if patch(stdout=tmpf):
             tmpf.seek(0)

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -117,9 +117,11 @@ def patch(stdout=None):
 if __name__ == "__main__":
     with tempfile.TemporaryFile(mode='w+t') as tmpf:
         if patch(stdout=tmpf):
-            msg = EmailMessage()
             tmpf.seek(0)
-            msg.set_content(tmpf.read())
+            report = tmpf.read()
+            log.debug(report)
+            msg = EmailMessage()
+            msg.set_content(report)
             msg['From'] = mailfrom
             msg['To'] = mailto
             msg['Subject'] = mailsubject

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -146,14 +146,14 @@ def exchandler(type, value, traceback):
 if __name__ == "__main__":
     sys.excepthook = exchandler
     with tempfile.TemporaryFile(mode='w+t') as tmpf:
-        stdout = logging.StreamHandler(stream=tmpf)
-        stdout.setLevel(logging.WARNING)
-        stdout.setFormatter(logging.Formatter(fmt="\n%(message)s"))
-        logging.getLogger().addHandler(stdout)
+        report_hdlr = logging.StreamHandler(stream=tmpf)
+        report_hdlr.setLevel(logging.WARNING)
+        report_hdlr.setFormatter(logging.Formatter(fmt="\n%(message)s"))
+        logging.getLogger().addHandler(report_hdlr)
         if patch(stdout=tmpf):
-            stdout.flush()
-            logging.getLogger().removeHandler(stdout)
-            stdout.close()
+            report_hdlr.flush()
+            logging.getLogger().removeHandler(report_hdlr)
+            report_hdlr.close()
             tmpf.seek(0)
             report = tmpf.read()
             log.debug(report)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     author_email = "rolf@rotkraut.de",
     url = "https://github.com/RKrahl/auto-patch",
     license = "Apache-2.0",
-    requires = [],
+    requires = ["systemd"],
     scripts = ["scripts/auto-patch.py"],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Add logging.  Close #3.

This adds up to three logging handlers:
- log messages go to the systemd journal.
- include log messages into the mail report.
- if `stderr` is a tty, e.g. if the script is run interactively, additionally log to `stderr`.

This adds a dependency on `python-systemd`.