### PR TITLE
Review build tool chain

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -11,7 +11,8 @@ jobs:
           - '3.7'
           - '3.8'
           - '3.9'
-          - '3.10.0-beta - 3.10.0'
+          - '3.10'
+          - '3.11.0-beta - 3.11.0'
         os: [ubuntu-latest]
     steps:
       - name: Check out repository code

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
+__pycache__/
 /.env
-/.version
 /MANIFEST
+/_meta.py
 /build/
 /dist/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,12 +16,18 @@ Misc
 
 + `#7`_, `#10`_: add a test suite.
 
+Bug fixes and minor changes
+---------------------------
+
++ `#12`__: review build tool chain.
+
 .. _#3: https://github.com/RKrahl/auto-patch/issues/3
 .. _#5: https://github.com/RKrahl/auto-patch/pull/5
 .. _#6: https://github.com/RKrahl/auto-patch/issues/6
 .. _#7: https://github.com/RKrahl/auto-patch/issues/7
 .. _#10: https://github.com/RKrahl/auto-patch/pull/10
 .. _#11: https://github.com/RKrahl/auto-patch/pull/11
+.. _#12: https://github.com/RKrahl/auto-patch/pull/12
 
 
 1.0.3 (2020-10-24)
@@ -30,7 +36,7 @@ Misc
 Bug fixes and minor changes
 ---------------------------
 
-+ Fix a syntx error.
++ Fix a syntax error.
 
 
 1.0.2 (2020-10-20)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
-include .version
 include CHANGES.rst
 include LICENSE.txt
 include MANIFEST.in
 include README.rst
+include _meta.py
 include systemd/*
 include tests/conftest.py
 include tests/pytest.ini

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include LICENSE.txt
 include MANIFEST.in
 include README.rst
 include _meta.py
+include etc/auto-patch.cfg
 include systemd/*
 include tests/conftest.py
 include tests/pytest.ini

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,15 @@ sdist:
 
 clean:
 	rm -rf build
-	rm -rf tests/.pytest_cache
+	rm -rf __pycache__
 
 distclean: clean
-	rm -f MANIFEST .version
+	rm -f MANIFEST _meta.py
 	rm -rf dist
+	rm -rf tests/.pytest_cache
 
 
-.PHONY: build test sdist clean distclean
+meta:
+	$(PYTHON) setup.py meta
+
+.PHONY: build test sdist clean distclean meta

--- a/README.rst
+++ b/README.rst
@@ -32,6 +32,8 @@ External programs:
 
 Required library packages:
 
++ `setuptools`_
+
 + `python-systemd`_
 
 Optional library packages:
@@ -69,6 +71,7 @@ permissions and limitations under the License.
 
 
 .. _zypper: https://github.com/openSUSE/zypper
+.. _setuptools: https://github.com/pypa/setuptools/
 .. _python-systemd: https://github.com/systemd/python-systemd
 .. _setuptools_scm: https://github.com/pypa/setuptools_scm
 .. _pytest: https://pytest.org/

--- a/auto-patch.spec
+++ b/auto-patch.spec
@@ -7,6 +7,7 @@ License:	Apache-2.0
 Group:		System/Management
 Source:		%{name}-%{version}.tar.gz
 BuildRequires:	python3-base >= 3.5
+BuildRequires:	python3-setuptools
 BuildRequires:	systemd-rpm-macros
 Requires:	lsof
 Requires:	python3-systemd

--- a/auto-patch.spec
+++ b/auto-patch.spec
@@ -32,6 +32,8 @@ python3 setup.py build
 %install
 python3 setup.py install --prefix=%{_prefix} --root=%{buildroot} --install-scripts=%{_sbindir}
 mv %{buildroot}%{_sbindir}/auto-patch.py %{buildroot}%{_sbindir}/auto-patch
+install -d -m 755 %{buildroot}%{_sysconfdir}
+cp -p etc/auto-patch.cfg %{buildroot}%{_sysconfdir}
 install -d -m 755 %{buildroot}%{_unitdir}
 cp -p systemd/* %{buildroot}%{_unitdir}
 

--- a/auto-patch.spec
+++ b/auto-patch.spec
@@ -1,3 +1,5 @@
+%bcond_without tests
+
 Name:		auto-patch
 Version:	$version
 Release:	0
@@ -9,6 +11,11 @@ Source:		%{name}-%{version}.tar.gz
 BuildRequires:	python3-base >= 3.5
 BuildRequires:	python3-setuptools
 BuildRequires:	systemd-rpm-macros
+%if %{with tests}
+BuildRequires:	python3-distutils-pytest
+BuildRequires:	python3-pytest >= 3.0
+BuildRequires:	python3-systemd
+%endif
 Requires:	lsof
 Requires:	python3-systemd
 Requires:	systemd
@@ -36,6 +43,12 @@ install -d -m 755 %{buildroot}%{_sysconfdir}
 cp -p etc/auto-patch.cfg %{buildroot}%{_sysconfdir}
 install -d -m 755 %{buildroot}%{_unitdir}
 cp -p systemd/* %{buildroot}%{_unitdir}
+
+
+%if %{with tests}
+%check
+python3 setup.py test
+%endif
 
 
 %pre

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,8 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: System :: Systems Administration",
     ],
     python_requires = ">=3.5",

--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,5 @@ setup(
     python_requires = ">=3.5",
     install_requires = ["systemd"],
     scripts = ["scripts/auto-patch.py"],
-    data_files = [("/etc", ["etc/auto-patch.cfg"])],
     cmdclass = dict(cmdclass, sdist=sdist, meta=meta),
 )

--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,11 @@ other system updates.  It also provides systemd unit files to
 automatically call that script regularly.
 """
 
+import setuptools
+from setuptools import setup
+import setuptools.command.build_py
 import distutils.command.sdist
-from distutils.core import setup
-import distutils.log
+from distutils import log
 from glob import glob
 from pathlib import Path
 import string
@@ -19,27 +21,47 @@ except (ImportError, AttributeError):
 try:
     import setuptools_scm
     version = setuptools_scm.get_version()
-    with open(".version", "wt") as f:
-        f.write(version)
 except (ImportError, LookupError):
     try:
-        with open(".version", "rt") as f:
-            version = f.read()
-    except OSError:
-        distutils.log.warn("warning: cannot determine version number")
+        import _meta
+        version = _meta.__version__
+    except ImportError:
+        log.warn("warning: cannot determine version number")
         version = "UNKNOWN"
 
-doclines = __doc__.strip().split("\n")
+docstring = __doc__
 
 
+class meta(setuptools.Command):
+    description = "generate meta files"
+    user_options = []
+    meta_template = '''
+__version__ = "%(version)s"
+'''
+    def initialize_options(self):
+        pass
+    def finalize_options(self):
+        pass
+    def run(self):
+        values = {
+            'version': self.distribution.get_version(),
+            'doc': docstring
+        }
+        with Path("_meta.py").open("wt") as f:
+            print(self.meta_template % values, file=f)
+
+# Note: Do not use setuptools for making the source distribution,
+# rather use the good old distutils instead.
+# Rationale: https://rhodesmill.org/brandon/2009/eby-magic/
 class sdist(distutils.command.sdist.sdist):
     def run(self):
+        self.run_command('meta')
         super().run()
         subst = {
             "version": self.distribution.get_version(),
             "url": self.distribution.get_url(),
-            "description": self.distribution.get_description(),
-            "long_description": self.distribution.get_long_description(),
+            "description": docstring.split("\n")[0],
+            "long_description": docstring.split("\n", maxsplit=2)[2].strip(),
         }
         for spec in glob("*.spec"):
             with Path(spec).open('rt') as inf:
@@ -47,18 +69,18 @@ class sdist(distutils.command.sdist.sdist):
                     outf.write(string.Template(inf.read()).substitute(subst))
 
 
+with Path("README.rst").open("rt", encoding="utf8") as f:
+    readme = f.read()
+
 setup(
     name = "auto-patch",
     version = version,
-    description = doclines[0],
-    long_description = "\n".join(doclines[2:]),
+    description = docstring.split("\n")[0],
+    long_description = readme,
+    url = "https://github.com/RKrahl/auto-patch",
     author = "Rolf Krahl",
     author_email = "rolf@rotkraut.de",
-    url = "https://github.com/RKrahl/auto-patch",
     license = "Apache-2.0",
-    requires = ["systemd"],
-    scripts = ["scripts/auto-patch.py"],
-    data_files = [("/etc", ["etc/auto-patch.cfg"])],
     classifiers = [
         "Development Status :: 4 - Beta",
         "Intended Audience :: System Administrators",
@@ -72,6 +94,9 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Topic :: System :: Systems Administration",
     ],
-    cmdclass = dict(cmdclass, sdist=sdist),
+    python_requires = ">=3.5",
+    install_requires = ["systemd"],
+    scripts = ["scripts/auto-patch.py"],
+    data_files = [("/etc", ["etc/auto-patch.cfg"])],
+    cmdclass = dict(cmdclass, sdist=sdist, meta=meta),
 )
-

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,8 @@ setup(
     ],
     python_requires = ">=3.5",
     install_requires = ["systemd"],
+    packages = [],
+    py_modules = [],
     scripts = ["scripts/auto-patch.py"],
     cmdclass = dict(cmdclass, sdist=sdist, meta=meta),
 )


### PR DESCRIPTION
Review tool chain to build the package:
- switch from `distutils` to `setuptools` in `setup.py` where appropriate,
- generate a `_meta` module to store the version number,
- do not install the config file from `setup.py`,
- conditionally add tests in the spec file,
- misc review.