### PR TITLE
Send a report also in the case of certain errors from zypper

### DIFF
--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -70,7 +70,8 @@ def logging_add_report(cfg, stream):
     root = logging.getLogger()
     report_hdlr = logging.StreamHandler(stream=stream)
     report_hdlr.setLevel(cfg.get('report_level'))
-    report_hdlr.setFormatter(logging.Formatter(fmt="\n%(message)s"))
+    fmt = "\n%(levelname)s: %(message)s"
+    report_hdlr.setFormatter(logging.Formatter(fmt=fmt))
     root.addHandler(report_hdlr)
     try:
         yield None

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -292,31 +292,40 @@ def patch(stdout=None):
                 err.Message += (".  Giving up after %d tries." % try_count)
                 raise err
 
+def make_report(logfile):
+    logfile.seek(0)
+    report = logfile.read()
+    log.debug(report)
+    if config['mailreport'].getboolean('report'):
+        msg = EmailMessage()
+        msg.set_content(report)
+        msg['From'] = config['mailreport'].get('mailfrom')
+        msg['To'] = config['mailreport'].get('mailto')
+        msg['Subject'] = config['mailreport'].get('subject')
+        mailhost = config['mailreport'].get('mailhost')
+        with smtplib.SMTP(mailhost) as smtp:
+            smtp.send_message(msg)
+
 def main():
     setup_logging(config['logging'])
     with tempfile.TemporaryFile(mode='w+t') as tmpf:
+        exit_code = 0
         with logging_add_report(config['logging'], tmpf):
-            have_patches = patch(stdout=tmpf)
-        if have_patches:
-            tmpf.seek(0)
-            report = tmpf.read()
-            log.debug(report)
-            if config['mailreport'].getboolean('report'):
-                msg = EmailMessage()
-                msg.set_content(report)
-                msg['From'] = config['mailreport'].get('mailfrom')
-                msg['To'] = config['mailreport'].get('mailto')
-                msg['Subject'] = config['mailreport'].get('subject')
-                mailhost = config['mailreport'].get('mailhost')
-                with smtplib.SMTP(mailhost) as smtp:
-                    smtp.send_message(msg)
+            try:
+                have_patches = patch(stdout=tmpf)
+            except (ZypperCommitError, ZypperRPMScriptfailed,
+                    ZypperSignal) as err:
+                log.error(err)
+                exit_code = err.ExitCode
+        if exit_code or have_patches:
+            make_report(tmpf)
+        return exit_code
 
 if __name__ == "__main__":
     try:
-        main()
+        exit_code = main()
     except (ZypperPrivilegesError, ZypperNoReposError, ZypperLockedError,
-            ZypperCommitError, ZypperSignal, ZypperReposSkipped,
-            ZypperRPMScriptfailed) as err:
+            ZypperReposSkipped) as err:
         log.error(err)
         sys.exit(err.ExitCode)
     except ZypperExitException as err:
@@ -327,3 +336,4 @@ if __name__ == "__main__":
         log.critical("Internal error %s: %s", type(err).__name__, err,
                      exc_info=err)
         sys.exit(-1)
+    sys.exit(exit_code)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,7 +122,7 @@ class AutoPatchCaller:
         p.join()
         assert p.exitcode == exitcode
 
-    def check_report(self):
+    def check_report(self, extra_msg=None):
         with open("report.pickle", "rb") as f:
             host = pickle.load(f)
             msg = pickle.load(f)
@@ -132,4 +132,7 @@ class AutoPatchCaller:
             idx = body.find(res.stdout, idx)
             assert idx >= 0
             idx += len(res.stdout)
+        if extra_msg:
+            idx = body.find(extra_msg, idx)
+            assert idx >= 0
         return host, msg

--- a/tests/test_02_exitcode.py
+++ b/tests/test_02_exitcode.py
@@ -36,7 +36,6 @@ def test_error_permission(tmpdir):
             caller.check_report()
 
 
-@pytest.mark.xfail(reason="Issue #15")
 def test_error_scripterr(tmpdir):
     """A %post() scriptlet from one of the packages failed.
 

--- a/tests/test_02_exitcode.py
+++ b/tests/test_02_exitcode.py
@@ -34,3 +34,17 @@ def test_error_permission(tmpdir):
         # assert that no mail report has been sent:
         with pytest.raises(FileNotFoundError):
             caller.check_report()
+
+
+@pytest.mark.xfail(reason="Issue #15")
+def test_error_scripterr(tmpdir):
+    """A %post() scriptlet from one of the packages failed.
+
+    This may happen, though rarely.  The auto-patch should report the
+    error, but still deliver a report.
+    """
+    # FIXME: verify that the error is logged
+    with tmpdir.as_cwd():
+        caller = AutoPatchCaller.get_caller("err_scripterr")
+        caller.run(exitcode=107)
+        caller.check_report()

--- a/tests/test_02_exitcode.py
+++ b/tests/test_02_exitcode.py
@@ -42,8 +42,7 @@ def test_error_scripterr(tmpdir):
     This may happen, though rarely.  The auto-patch should report the
     error, but still deliver a report.
     """
-    # FIXME: verify that the error is logged
     with tmpdir.as_cwd():
         caller = AutoPatchCaller.get_caller("err_scripterr")
         caller.run(exitcode=107)
-        caller.check_report()
+        caller.check_report(extra_msg="ERROR:")

--- a/tests/zypper-result-data.json
+++ b/tests/zypper-result-data.json
@@ -450,9 +450,6 @@
       "cmd": "patch",
       "returncode": 107,
       "stdout": "\nThe following 2 packages are going to be upgraded:\n  python3-pip python3-pytest\n\nThe following NEW patch is going to be installed:\n  openSUSE-SLE-15.6-2025-2574\n\n2 packages to upgrade.\n\nPackage download size:     2.2 MiB\n\nPackage install size change:\n              |      10.2 MiB  required by packages that will be installed\n    -1.8 MiB  |  -   12.0 MiB  released by packages that will be removed\n\nBackend:  classic_rpmtrans\nContinue? [y/n/v/...? shows all options] (y): y\n\n"
-    },
-    {
-      "cmd": "ps"
     }
   ]
 }

--- a/tests/zypper-result-data.json
+++ b/tests/zypper-result-data.json
@@ -435,5 +435,24 @@
       "returncode": 5,
       "stderr": "Root privileges are required to run this command.\n"
     }
+  ],
+  "err_scripterr": [
+    {
+      "cmd": "patch-check",
+      "returncode": 100,
+      "stdout": "\nCategory    | Patches\n------------+--------\nrecommended | 1\n\n1 patch needed (0 security patches)\n"
+    },
+    {
+      "cmd": "list-patches",
+      "stdout": "\nRepository                                                   | Name                        | Category    | Severity | Interactive | Status | Since      | Summary\n-------------------------------------------------------------+-----------------------------+-------------+----------+-------------+--------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------\nUpdate repository with updates from SUSE Linux Enterprise 15 | openSUSE-SLE-15.6-2025-2574 | recommended | moderate | ---         | needed | 2025-08-08 | Recommended update for python3-PyNaCl, python3-atomicwrites, python3-cryptography, python3-cryptography-vectors, python3-more-itertools, python3-paramiko, python3-pip, python3-pyOpenSSL, python3-pytest, python3-setuptools\n\n1 patch needed (0 security patches)\n\n"
+    },
+    {
+      "cmd": "patch",
+      "returncode": 107,
+      "stdout": "\nThe following 2 packages are going to be upgraded:\n  python3-pip python3-pytest\n\nThe following NEW patch is going to be installed:\n  openSUSE-SLE-15.6-2025-2574\n\n2 packages to upgrade.\n\nPackage download size:     2.2 MiB\n\nPackage install size change:\n              |      10.2 MiB  required by packages that will be installed\n    -1.8 MiB  |  -   12.0 MiB  released by packages that will be removed\n\nBackend:  classic_rpmtrans\nContinue? [y/n/v/...? shows all options] (y): y\n\n"
+    },
+    {
+      "cmd": "ps"
+    }
   ]
 }


### PR DESCRIPTION
Still send a report in cases of errors from `zypper` where some patches might have been (partly) installed:

- on error during installation or removal of packages
- if some packages install script returned an error
- on exit of `zypper` after receiving a `SIGINT` or `SIGTERM`

Close #15.