### PR TITLE
Review build tool chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ distclean: clean
 	rm -rf dist
 	rm -rf tests/.pytest_cache
 
-
 meta:
 	$(PYTHON) setup.py meta
+
 
 .PHONY: build test sdist clean distclean meta

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,11 @@ Required library packages:
 
 + `python-systemd`_
 
+  Note: it is recommended to install this from the package repository
+  of your Linux distribution, e.g. on openSUSE and SLE, run something
+  like `zypper install python3-systemd`.  If you need to install it
+  from PyPI, please note that the package name there is `systemd-python`_.
+
 Optional library packages:
 
 + `git-props`_
@@ -73,6 +78,7 @@ permissions and limitations under the License.
 .. _zypper: https://github.com/openSUSE/zypper
 .. _setuptools: https://github.com/pypa/setuptools/
 .. _python-systemd: https://github.com/systemd/python-systemd
+.. _systemd-python: https://pypi.org/project/systemd-python/
 .. _git-props: https://github.com/RKrahl/git-props
 .. _pytest: https://pytest.org/
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest

--- a/README.rst
+++ b/README.rst
@@ -63,10 +63,10 @@ Optional library packages:
 Copyright and License
 ---------------------
 
-Copyright 2020–2022 Rolf Krahl
+Copyright 2020–2025 Rolf Krahl
 
 Licensed under the `Apache License`_, Version 2.0 (the "License"); you
-may not use this file except in compliance with the License.
+may not use this package except in compliance with the License.
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.rst
+++ b/README.rst
@@ -38,13 +38,13 @@ Required library packages:
 
 Optional library packages:
 
-+ `setuptools_scm`_
++ `git-props`_
 
-  The version number is managed using this package.  All source
-  distributions add a static text file with the version number and
-  fall back using that if `setuptools_scm` is not available.  So this
-  package is only needed to build out of the plain development source
-  tree as cloned from GitHub.
+  This package is used to extract some metadata such as the version
+  number out of git, the version control system.  All releases embed
+  that metadata in the distribution.  So this package is only needed
+  to build out of the plain development source tree as cloned from
+  GitHub, but not to build a release distribution.
 
 + `pytest`_ >= 3.0
 
@@ -73,7 +73,7 @@ permissions and limitations under the License.
 .. _zypper: https://github.com/openSUSE/zypper
 .. _setuptools: https://github.com/pypa/setuptools/
 .. _python-systemd: https://github.com/systemd/python-systemd
-.. _setuptools_scm: https://github.com/pypa/setuptools_scm
+.. _git-props: https://github.com/RKrahl/git-props
 .. _pytest: https://pytest.org/
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest
 .. _Apache License: https://www.apache.org/licenses/LICENSE-2.0

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,16 @@ try:
 except (ImportError, AttributeError):
     cmdclass = dict()
 try:
-    import setuptools_scm
-    version = setuptools_scm.get_version()
+    import gitprops
+    release = gitprops.get_last_release()
+    release = release and str(release)
+    version = str(gitprops.get_version())
 except (ImportError, LookupError):
     try:
-        import _meta
-        version = _meta.__version__
+        from _meta import release, version
     except ImportError:
         log.warn("warning: cannot determine version number")
-        version = "UNKNOWN"
+        release = version = "UNKNOWN"
 
 docstring = __doc__
 
@@ -35,16 +36,19 @@ class meta(setuptools.Command):
     description = "generate meta files"
     user_options = []
     meta_template = '''
-__version__ = "%(version)s"
+release = %(release)r
+version = %(version)r
 '''
     def initialize_options(self):
         pass
     def finalize_options(self):
         pass
     def run(self):
+        version = self.distribution.get_version()
+        log.info("version: %s", version)
         values = {
-            'version': self.distribution.get_version(),
-            'doc': docstring
+            'release': release,
+            'version': version,
         }
         with Path("_meta.py").open("wt") as f:
             print(self.meta_template % values, file=f)

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ setup(
         "Topic :: System :: Systems Administration",
     ],
     python_requires = ">=3.6",
-    install_requires = ["systemd"],
+    install_requires = ["setuptools", "systemd-python"],
     packages = [],
     py_modules = [],
     scripts = ["scripts/auto-patch.py"],

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from setuptools import setup
 import distutils.command.sdist
 import distutils.dist
 from distutils import log
-from glob import glob
 from pathlib import Path
 import string
 try:
@@ -43,16 +42,20 @@ distutils.dist.DistributionMetadata.get_fullname = _fixed_get_fullname
 
 
 class meta(setuptools.Command):
+
     description = "generate meta files"
     user_options = []
     meta_template = '''
 release = %(release)r
 version = %(version)r
 '''
+
     def initialize_options(self):
         pass
+
     def finalize_options(self):
         pass
+
     def run(self):
         version = self.distribution.get_version()
         log.info("version: %s", version)
@@ -62,6 +65,7 @@ version = %(version)r
         }
         with Path("_meta.py").open("wt") as f:
             print(self.meta_template % values, file=f)
+
 
 # Note: Do not use setuptools for making the source distribution,
 # rather use the good old distutils instead.
@@ -76,8 +80,8 @@ class sdist(distutils.command.sdist.sdist):
             "description": docstring.split("\n")[0],
             "long_description": docstring.split("\n", maxsplit=2)[2].strip(),
         }
-        for spec in glob("*.spec"):
-            with Path(spec).open('rt') as inf:
+        for spec in Path().glob("*.spec"):
+            with spec.open('rt') as inf:
                 with Path(self.dist_dir, spec).open('wt') as outf:
                     outf.write(string.Template(inf.read()).substitute(subst))
 
@@ -90,6 +94,7 @@ setup(
     version = version,
     description = docstring.split("\n")[0],
     long_description = readme,
+    long_description_content_type = "text/x-rst",
     url = "https://github.com/RKrahl/auto-patch",
     author = "Rolf Krahl",
     author_email = "rolf@rotkraut.de",
@@ -108,8 +113,13 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: System :: Systems Administration",
     ],
+    project_urls = dict(
+        Source="https://github.com/RKrahl/auto-patch",
+        Download=("https://github.com/RKrahl/auto-patch/releases/%s/" % release),
+    ),
     python_requires = ">=3.6",
     install_requires = ["setuptools", "systemd-python"],
     packages = [],

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ automatically call that script regularly.
 import setuptools
 from setuptools import setup
 import distutils.command.sdist
+import distutils.dist
 from distutils import log
 from glob import glob
 from pathlib import Path
@@ -30,6 +31,15 @@ except (ImportError, LookupError):
         release = version = "UNKNOWN"
 
 docstring = __doc__
+
+
+# Enforcing of PEP 625 has been added in setuptools 69.3.0.  We don't
+# want this, we want to keep control on the name of the sdist
+# ourselves.  Disable it.
+def _fixed_get_fullname(self):
+    return "%s-%s" % (self.get_name(), self.get_version())
+
+distutils.dist.DistributionMetadata.get_fullname = _fixed_get_fullname
 
 
 class meta(setuptools.Command):


### PR DESCRIPTION
Some review of the tool chain to build the package:

- Drop `setuptools_scm` in favour of `git-props`,
- Disable [PEP 625](https://peps.python.org/pep-0625/) enforcing added in [setuptools 69.3.0](https://setuptools.pypa.io/en/stable/history.html#v69-3-0),
- Fix dependencies, add a note to the README hinting that [python-systemd](https://github.com/systemd/python-systemd) is not to be confused with the PyPI package of the same name,
- Misc.