### PR TITLE
Send a mailreport in the case of errors from zypper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,13 +7,21 @@ Changelog
 1.3.0 (not yet released)
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
+Behavioral change
+-----------------
+
++ `#24`_, `#28`_: always send a mail report in the case of errors from
+  `zypper`.
+
 Internal
 --------
 
 + `#26`_, `#27`_: review test suite.
 
+.. _#24: https://github.com/RKrahl/auto-patch/issues/24
 .. _#26: https://github.com/RKrahl/auto-patch/pull/26
 .. _#27: https://github.com/RKrahl/auto-patch/pull/27
+.. _#28: https://github.com/RKrahl/auto-patch/pull/28
 
 
 .. _changes-1_2_0:

--- a/scripts/auto-patch.py
+++ b/scripts/auto-patch.py
@@ -334,8 +334,7 @@ def main():
         with logging_add_report(config['logging'], tmpf):
             try:
                 have_patches = patch(stdout=tmpf)
-            except (ZypperCommitError, ZypperRPMScriptfailed,
-                    ZypperSignal) as err:
+            except ZypperExitException as err:
                 log.error(err)
                 exit_code = err.ExitCode
         if exit_code or have_patches:
@@ -345,14 +344,6 @@ def main():
 if __name__ == "__main__":
     try:
         exit_code = main()
-    except (ZypperPrivilegesError, ZypperNoReposError, ZypperLockedError,
-            ZypperReposSkipped) as err:
-        log.error(err)
-        sys.exit(err.ExitCode)
-    except ZypperExitException as err:
-        log.critical("Internal error %s: %s", type(err).__name__, err,
-                     exc_info=err)
-        sys.exit(err.ExitCode)
     except Exception as err:
         log.critical("Internal error %s: %s", type(err).__name__, err,
                      exc_info=err)

--- a/tests/test_02_exitcode.py
+++ b/tests/test_02_exitcode.py
@@ -9,7 +9,6 @@ import pytest
 from conftest import AutoPatchCaller
 
 
-@pytest.mark.xfail(reason="Issue #24")
 def test_error_syntax(tmpdir):
     """A syntax error in the zypper call.
 
@@ -21,7 +20,6 @@ def test_error_syntax(tmpdir):
         caller.check_report(extra_msg="ERROR:")
 
 
-@pytest.mark.xfail(reason="Issue #24")
 def test_error_permission(tmpdir):
     """Insufficient privileges calling zypper.
 
@@ -46,7 +44,6 @@ def test_error_scripterr(tmpdir):
         caller.check_report(extra_msg="ERROR:")
 
 
-@pytest.mark.xfail(reason="Issue #24")
 def test_error_license(tmpdir):
     """Patch fails due to missing license confirmation.
 

--- a/tests/test_02_exitcode.py
+++ b/tests/test_02_exitcode.py
@@ -9,6 +9,7 @@ import pytest
 from conftest import AutoPatchCaller
 
 
+@pytest.mark.xfail(reason="Issue #24")
 def test_error_syntax(tmpdir):
     """A syntax error in the zypper call.
 
@@ -17,11 +18,10 @@ def test_error_syntax(tmpdir):
     with tmpdir.as_cwd():
         caller = AutoPatchCaller.get_caller("err_syntax")
         caller.run(exitcode=2)
-        # assert that no mail report has been sent:
-        with pytest.raises(FileNotFoundError):
-            caller.check_report()
+        caller.check_report(extra_msg="ERROR:")
 
 
+@pytest.mark.xfail(reason="Issue #24")
 def test_error_permission(tmpdir):
     """Insufficient privileges calling zypper.
 
@@ -31,9 +31,7 @@ def test_error_permission(tmpdir):
     with tmpdir.as_cwd():
         caller = AutoPatchCaller.get_caller("err_permissions")
         caller.run(exitcode=5)
-        # assert that no mail report has been sent:
-        with pytest.raises(FileNotFoundError):
-            caller.check_report()
+        caller.check_report(extra_msg="ERROR:")
 
 
 def test_error_scripterr(tmpdir):
@@ -48,6 +46,7 @@ def test_error_scripterr(tmpdir):
         caller.check_report(extra_msg="ERROR:")
 
 
+@pytest.mark.xfail(reason="Issue #24")
 def test_error_license(tmpdir):
     """Patch fails due to missing license confirmation.
 
@@ -58,6 +57,4 @@ def test_error_license(tmpdir):
     with tmpdir.as_cwd():
         caller = AutoPatchCaller.get_caller("no_license_consent")
         caller.run(exitcode=4)
-        # assert that no mail report has been sent:
-        with pytest.raises(FileNotFoundError):
-            caller.check_report()
+        caller.check_report(extra_msg="ERROR:")

--- a/tests/test_02_retry.py
+++ b/tests/test_02_retry.py
@@ -28,6 +28,7 @@ def test_locked_in_between(tmpdir):
         caller.check_report()
 
 
+@pytest.mark.xfail(reason="Issue #24")
 def test_locked_final(tmpdir):
     """The auto-patch workflow is interrupted by a persistent lock,
     auto-patch eventually gives up waiting.
@@ -35,11 +36,10 @@ def test_locked_final(tmpdir):
     with tmpdir.as_cwd():
         caller = AutoPatchCaller.get_caller("locked_final", config=no_wait)
         caller.run(exitcode=7)
-        # assert that no mail report has been sent:
-        with pytest.raises(FileNotFoundError):
-            caller.check_report()
+        caller.check_report(extra_msg="ERROR:")
 
 
+@pytest.mark.xfail(reason="Issue #24")
 def test_locked_complete(tmpdir):
     """A persistent lock blocks auto-patch completely, auto-patch
     eventually gives up waiting, not a single zypper succeeded.
@@ -47,9 +47,7 @@ def test_locked_complete(tmpdir):
     with tmpdir.as_cwd():
         caller = AutoPatchCaller.get_caller("locked_complete", config=no_wait)
         caller.run(exitcode=7)
-        # assert that no mail report has been sent:
-        with pytest.raises(FileNotFoundError):
-            caller.check_report()
+        caller.check_report(extra_msg="ERROR:")
 
 
 def test_no_network_at_start(tmpdir):
@@ -61,6 +59,7 @@ def test_no_network_at_start(tmpdir):
         caller.check_report()
 
 
+@pytest.mark.xfail(reason="Issue #24")
 def test_no_network_complete(tmpdir):
     """A persistent network failure blocks auto-patch completely,
     auto-patch eventually gives up waiting, not a single zypper
@@ -69,6 +68,4 @@ def test_no_network_complete(tmpdir):
     with tmpdir.as_cwd():
         caller = AutoPatchCaller.get_caller("no_net_complete", config=no_wait)
         caller.run(exitcode=106)
-        # assert that no mail report has been sent:
-        with pytest.raises(FileNotFoundError):
-            caller.check_report()
+        caller.check_report(extra_msg="ERROR:")

--- a/tests/test_02_retry.py
+++ b/tests/test_02_retry.py
@@ -28,7 +28,6 @@ def test_locked_in_between(tmpdir):
         caller.check_report()
 
 
-@pytest.mark.xfail(reason="Issue #24")
 def test_locked_final(tmpdir):
     """The auto-patch workflow is interrupted by a persistent lock,
     auto-patch eventually gives up waiting.
@@ -39,7 +38,6 @@ def test_locked_final(tmpdir):
         caller.check_report(extra_msg="ERROR:")
 
 
-@pytest.mark.xfail(reason="Issue #24")
 def test_locked_complete(tmpdir):
     """A persistent lock blocks auto-patch completely, auto-patch
     eventually gives up waiting, not a single zypper succeeded.
@@ -59,7 +57,6 @@ def test_no_network_at_start(tmpdir):
         caller.check_report()
 
 
-@pytest.mark.xfail(reason="Issue #24")
 def test_no_network_complete(tmpdir):
     """A persistent network failure blocks auto-patch completely,
     auto-patch eventually gives up waiting, not a single zypper


### PR DESCRIPTION
Change the behavior of the `auto-patch` script: always send a mail report in the case of errors from `zypper`, even if this error is assumed not to occur in regular operation.

Close #24.